### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/classes/liri.bbclass
+++ b/classes/liri.bbclass
@@ -1,6 +1,6 @@
 LIRI_GIT_BRANCH ?= "develop"
 
-SRC_URI = "git://github.com/lirios/${@'${BPN}'.replace('liri-', '')}.git;protocol=git;branch=${LIRI_GIT_BRANCH}"
+SRC_URI = "git://github.com/lirios/${@'${BPN}'.replace('liri-', '')}.git;protocol=https;branch=${LIRI_GIT_BRANCH}"
 
 DEPENDS += "qtbase qtdeclarative extra-cmake-modules-native"
 

--- a/classes/lxqt.bbclass
+++ b/classes/lxqt.bbclass
@@ -4,7 +4,7 @@ HOMEPAGE = "http://lxqt.org/"
 
 DEPENDS += "lxqt-build-tools qtbase qttools-native"
 
-SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += " \

--- a/recipes-kdab/hotspot/hotspot_git.bb
+++ b/recipes-kdab/hotspot/hotspot_git.bb
@@ -21,7 +21,7 @@ DEPENDS += " \
     kio \
     solid \
 "
-SRC_URI = "gitsm://github.com/KDAB/hotspot.git"
+SRC_URI = "gitsm://github.com/KDAB/hotspot.git;protocol=https"
 SRCREV = "a41a0a5ba1fead202bfdcb2198f192114d030484"
 S = "${WORKDIR}/git"
 PV = "1.1.0+git${SRCPV}"

--- a/recipes-liri/liri-browser/liri-browser_git.bb
+++ b/recipes-liri/liri-browser/liri-browser_git.bb
@@ -8,7 +8,7 @@ inherit qmake5
 
 PV = "0.0.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/lirios/browser.git;branch=develop"
+SRC_URI = "git://github.com/lirios/browser.git;branch=develop;protocol=https"
 SRCREV = "4f27d0b1abb85ad0166482128570b158c3b446aa"
 S = "${WORKDIR}/git"
 

--- a/recipes-liri/liri-calculator/liri-calculator_git.bb
+++ b/recipes-liri/liri-calculator/liri-calculator_git.bb
@@ -8,7 +8,7 @@ inherit qmake5
 
 PV = "0.0.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/lirios/calculator.git"
+SRC_URI = "git://github.com/lirios/calculator.git;protocol=https"
 SRCREV = "b86e70b2e408004408459349db3a7f1a7316570a"
 S = "${WORKDIR}/git"
 

--- a/recipes-liri/slime-engine/slime-engine_git.bb
+++ b/recipes-liri/slime-engine/slime-engine_git.bb
@@ -8,7 +8,7 @@ inherit qmake5
 
 PV = "0.0.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/tim-sueberkrueb/${BPN}.git"
+SRC_URI = "git://github.com/tim-sueberkrueb/${BPN}.git;protocol=https"
 SRCREV = "9d2fd26da9c38b2e5c4c1c4d994b193213559e2f"
 S = "${WORKDIR}/git"
 

--- a/recipes-lxqt/lxmenu-data/lxmenu-data_git.bb
+++ b/recipes-lxqt/lxmenu-data/lxmenu-data_git.bb
@@ -6,7 +6,7 @@ inherit autotools gettext
 
 DEPENDS = "glib-2.0-native intltool-native"
 
-SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 SRCREV = "3b14415ff9862e6b79577fd4b9a097965001b270"

--- a/recipes-lxqt/lxqt-build-tools/lxqt-build-tools_git.bb
+++ b/recipes-lxqt/lxqt-build-tools/lxqt-build-tools_git.bb
@@ -9,7 +9,7 @@ do_configure_append() {
     sed -i 's:set(LXQT_ETC_XDG_DIR.*:set(LXQT_ETC_XDG_DIR        "${sysconfdir}/xdg"):' ${B}/install/LXQtConfigVars.cmake
 }
 
-SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=https;branch=master"
 SRCREV = "61ed15b7346771a0e24dfeed0f244596fb08fdce"
 PV = "0.5.0"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-graphics/compton/compton_git.bb
+++ b/recipes-misc/recipes-graphics/compton/compton_git.bb
@@ -22,7 +22,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/chjj/compton.git \
+    git://github.com/chjj/compton.git;protocol=https \
     file://0001-Makefile-use-pkgconfig-to-find-libpcre.patch \
     file://0002-Makefile-don-t-build-manpages.patch \
 "

--- a/recipes-misc/recipes-graphics/ntk/ntk_git.bb
+++ b/recipes-misc/recipes-graphics/ntk/ntk_git.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPLv2 & FLTK"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f6b26344a24a941a01a5b0826e80b5ca"
 
 SRC_URI = " \
-    git://github.com/original-male/${BPN}.git \
+    git://github.com/original-male/${BPN}.git;protocol=https \
     file://0001-wscript-check-compile-instead-of-tun-check-datatype-.patch \
 "
 SRCREV = "1e3f5106d404562902bed2983403301db24a3f78"

--- a/recipes-misc/recipes-graphics/sddm/sddm_git.bb
+++ b/recipes-misc/recipes-graphics/sddm/sddm_git.bb
@@ -16,7 +16,7 @@ DEPENDS += "libpam"
 # Note: we should check default config changes by running sddm --example-config on target.
 # This is usually done during build but does not work for our cross environment
 SRC_URI = " \
-    git://github.com/sddm/${BPN}.git;protocol=git;branch=master \
+    git://github.com/sddm/${BPN}.git;protocol=https;branch=master \
     file://0001-fix-qml-install-dir.patch \
     file://0002-do-not-create-example-configutation-we-cannot-run-sd.patch \
     file://0001-Fix-build-with-Qt-5.11-1024.patch \

--- a/recipes-misc/recipes-graphics/touchegg-qt5/touchegg-qt5_git.bb
+++ b/recipes-misc/recipes-graphics/touchegg-qt5/touchegg-qt5_git.bb
@@ -8,7 +8,7 @@ inherit qmake5
 DEPENDS += "qtbase qtx11extras geis libxtst"
 
 SRC_URI = " \
-    git://github.com/JoseExposito/touchegg.git \
+    git://github.com/JoseExposito/touchegg.git;protocol=https \
     file://0001-fix-qt5-build.patch \
 "
 PV = "1.1.1+git${SRCPV}"

--- a/recipes-misc/recipes-hardhelper/qtiohelper/qtiohelper_git.bb
+++ b/recipes-misc/recipes-hardhelper/qtiohelper/qtiohelper_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=bd7b2c994af21d318bd2cd3b3f80c2d5"
 
 require recipes-qt/qt5/qt5.inc
 
-SRC_URI = "git://github.com/schnitzeltony/${BPN}.git;branch=master"
+SRC_URI = "git://github.com/schnitzeltony/${BPN}.git;branch=master;protocol=https"
 
 DEPENDS += "qtbase qtserialport"
 

--- a/recipes-misc/recipes-multimedia/ardour/ardour5_git.bb
+++ b/recipes-misc/recipes-multimedia/ardour/ardour5_git.bb
@@ -33,7 +33,7 @@ inherit waf distro_features_check gtk-icon-cache pkgconfig
 REQUIRED_DISTRO_FEATURE = "x11"
 
 SRC_URI = " \
-    git://github.com/Ardour/ardour.git \
+    git://github.com/Ardour/ardour.git;protocol=https \
     file://0001-remove-all-build-flags-that-cause-trouble-for-cross-.patch \
     file://0002-Use-ARM-NEON-intrinsics-if-available-for-mixing-func.patch \
     file://ardour5.desktop \

--- a/recipes-misc/recipes-multimedia/calf-studio-gear/calf_git.bb
+++ b/recipes-misc/recipes-multimedia/calf-studio-gear/calf_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    git://github.com/calf-studio-gear/calf.git \
+    git://github.com/calf-studio-gear/calf.git;protocol=https \
     file://0001-Do-store-calfmakerdf-commandline-for-later-use-in-qe.patch \
 "
 SRCREV = "f71e2742e1463906c3d44a4b33c1d90e3ad61acb"

--- a/recipes-misc/recipes-multimedia/carla/carla_git.bb
+++ b/recipes-misc/recipes-multimedia/carla/carla_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    git://github.com/falkTX/Carla.git \
+    git://github.com/falkTX/Carla.git;protocol=https \
     file://0001-Use-fluid-instead-of-ntk-fluid.patch \
     file://0002-do-not-try-to-cross-run-carla-lv2-export.patch \
     file://0003-Don-t-disable-EXPERIMENTAL_PLUGINS.patch \

--- a/recipes-misc/recipes-multimedia/csound/csound_git.bb
+++ b/recipes-misc/recipes-multimedia/csound/csound_git.bb
@@ -26,7 +26,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/csound/csound.git \
+    git://github.com/csound/csound.git;protocol=https \
     file://0001-Do-not-set-include-path-to-usr-local-include.patch \
     file://0002-Do-not-use-try_run-for-portaudio.patch \
     file://0003-strict-aliasing-errors.patch \

--- a/recipes-misc/recipes-multimedia/device-control/lpd8editor/lpd8editor_0.0.10.bb
+++ b/recipes-misc/recipes-multimedia/device-control/lpd8editor/lpd8editor_0.0.10.bb
@@ -11,7 +11,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/charlesfleche/lpd8editor.git \
+    git://github.com/charlesfleche/lpd8editor.git;protocol=https \
     file://lpd8-editor.desktop \
 "
 SRCREV = "bd15bd689329194a3c5c3d727c2318629b027e3a"

--- a/recipes-misc/recipes-multimedia/distrho/distrho-ports-extra.bb
+++ b/recipes-misc/recipes-multimedia/distrho/distrho-ports-extra.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    git://github.com/DISTRHO/DISTRHO-Ports-Extra.git \
+    git://github.com/DISTRHO/DISTRHO-Ports-Extra.git;protocol=https \
 "
 # TODO:
 # argolunar: no sound (presets?)

--- a/recipes-misc/recipes-multimedia/distrho/distrho-ports.bb
+++ b/recipes-misc/recipes-multimedia/distrho/distrho-ports.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    git://github.com/DISTRHO/DISTRHO-Ports.git \
+    git://github.com/DISTRHO/DISTRHO-Ports.git;protocol=https \
     file://0001-disable-pitchedDelay-it-uses-double-precision-SSE2-b.patch \
     file://0002-Refine-Plugin-do-not-include-xmmintrin.h.patch \
     \

--- a/recipes-misc/recipes-multimedia/distrho/dpf-plugins.bb
+++ b/recipes-misc/recipes-multimedia/distrho/dpf-plugins.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    git://github.com/DISTRHO/DPF-Plugins.git \
+    git://github.com/DISTRHO/DPF-Plugins.git;protocol=https \
     file://0001-Disable-modgui-we-don-t-support-modgui.patch \
 "
 

--- a/recipes-misc/recipes-multimedia/distrho/lv2-ttl-generator.bb
+++ b/recipes-misc/recipes-multimedia/distrho/lv2-ttl-generator.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=7b4d7947003bd60e5475fc61c6d014da \
 "
 
-SRC_URI = "git://github.com/DISTRHO/DPF.git"
+SRC_URI = "git://github.com/DISTRHO/DPF.git;protocol=https"
 SRCREV = "70cec6a9d0222b32abdcaec02cd7b01378c4d78b"
 S = "${WORKDIR}/git"
 PV = "0.0.0+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/dssi-vst/dssi-vst_git.bb
+++ b/recipes-misc/recipes-multimedia/dssi-vst/dssi-vst_git.bb
@@ -14,7 +14,7 @@ DEPENDS += " \
     zlib \
 "
 
-SRC_URI = "git://github.com/falkTX/dssi-vst.git"
+SRC_URI = "git://github.com/falkTX/dssi-vst.git;protocol=https"
 SRCREV = "9462b34563af84b452795d4924d4f18af9072529"
 S = "${WORKDIR}/git"
 PV = "0.9.2+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/helm/helm_git.bb
+++ b/recipes-misc/recipes-multimedia/helm/helm_git.bb
@@ -21,7 +21,7 @@ DEPENDS += " \
 "
 
 SRC_URI += " \
-    git://github.com/mtytel/helm.git \
+    git://github.com/mtytel/helm.git;protocol=https \
     file://0001-Makefile-remove-machine-detection-it-won-t-work-for-.patch \
     file://0002-do-not-create-ttl-files-it-won-t-work-fo-cross.patch \
     file://0003-use-standard-vst-path.patch \

--- a/recipes-misc/recipes-multimedia/hydrogen/hydrogen_git.bb
+++ b/recipes-misc/recipes-multimedia/hydrogen/hydrogen_git.bb
@@ -32,7 +32,7 @@ DEPENDS += " \
 # NOTE: download of drumkits might fail -> repeat builds of this recipe usually helps
 
 SRC_URI = " \
-    git://github.com/hydrogen-music/hydrogen.git \
+    git://github.com/hydrogen-music/hydrogen.git;protocol=https \
     file://0001-remove-qt5_use_modules.patch \
     file://0002-hydrogen.default.conf-do-not-show-developer-warnings.patch \
     file://0003-Fix-man-installation-path.patch \

--- a/recipes-misc/recipes-multimedia/infamousplugins/infamousplugins_0.2.04.bb
+++ b/recipes-misc/recipes-multimedia/infamousplugins/infamousplugins_0.2.04.bb
@@ -14,7 +14,7 @@ DEPENDS += " \
 inherit cmake pkgconfig gtk-icon-cache
 
 SRC_URI = " \
-    git://github.com/ssj71/infamousPlugins.git \
+    git://github.com/ssj71/infamousPlugins.git;protocol=https \
 "
 SRCREV = "970a5de32393cc92ab2144d6a8a5e92b302dc9b5"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-multimedia/libmp4v2/libmp4v2_git.bb
+++ b/recipes-misc/recipes-multimedia/libmp4v2/libmp4v2_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=eb3014b036b6d2151d944aef6a84c36f"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/sergiomb2/${BPN}.git"
+SRC_URI = "git://github.com/sergiomb2/${BPN}.git;protocol=https"
 SRCREV = "855e9674232808ff3be7191b697dfb56917db21f"
 S = "${WORKDIR}/git"
 PV = "2.1.0+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/libsmf/libsmf_git.bb
+++ b/recipes-misc/recipes-multimedia/libsmf/libsmf_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=73755aa03cb15d62bbf780d2c17f31b7"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/stump/libsmf.git"
+SRC_URI = "git://github.com/stump/libsmf.git;protocol=https"
 SRCREV = "692e728d2c13caa3896880216f19f5565ea03886"
 S = "${WORKDIR}/git"
 

--- a/recipes-misc/recipes-multimedia/lmms/lmms.inc
+++ b/recipes-misc/recipes-multimedia/lmms/lmms.inc
@@ -3,7 +3,7 @@ HOMEPAGE = "https://lmms.io"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=751419260aa954499f7abaabaa882bbe"
 
-SRC_URI = "gitsm://github.com/LMMS/${BPN}.git;branch=stable-1.2"
+SRC_URI = "gitsm://github.com/LMMS/${BPN}.git;branch=stable-1.2;protocol=https"
 SRCREV = "2f19fa11c886374adcc74990e52d3ed0473fbf08"
 S = "${WORKDIR}/git"
 PV = "1.2.0-rc6+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/lrdf/lrdf_0.5.0.bb
+++ b/recipes-misc/recipes-multimedia/lrdf/lrdf_0.5.0.bb
@@ -7,7 +7,7 @@ inherit autotools pkgconfig
 
 DEPENDS = "raptor2"
 
-SRC_URI = "git://github.com/swh/LRDF.git"
+SRC_URI = "git://github.com/swh/LRDF.git;protocol=https"
 SRCREV = "1057b8e542f7dd27e3e591e93c07d58bd2143b76"
 PV = "0.5.0+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-multimedia/mixxx/mixxx_git.bb
+++ b/recipes-misc/recipes-multimedia/mixxx/mixxx_git.bb
@@ -35,7 +35,7 @@ DEPENDS += " \
 #    gperftools
 
 SRC_URI = " \
-    git://github.com/mixxxdj/${BPN}.git;branch=2.1 \
+    git://github.com/mixxxdj/${BPN}.git;branch=2.1;protocol=https \
     file://0001-do-not-check-for-known-machine-types.patch \
     file://0002-force-using-system-soundtouch.patch \
     file://0003-align-path-of-qt-build-tools-to-our-needs.patch \

--- a/recipes-misc/recipes-multimedia/muse/muse_git.bb
+++ b/recipes-misc/recipes-multimedia/muse/muse_git.bb
@@ -22,7 +22,7 @@ DEPENDS += " \
 inherit cmake_qt5 pkgconfig gtk-icon-cache distro_features_check mime qt5-translation
 
 SRC_URI = " \
-    git://github.com/muse-sequencer/muse.git \
+    git://github.com/muse-sequencer/muse.git;protocol=https \
 "
 SRCREV = "02d9dc6abd757c3c1783fdd46dacd3c4ef2c0a6d"
 PV = "3.0.2+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/nekobee/nekobee.bb
+++ b/recipes-misc/recipes-multimedia/nekobee/nekobee.bb
@@ -12,7 +12,7 @@ DEPENDS += " \
     liblo \
 "
 
-SRC_URI = "git://github.com/gordonjcp/${BPN}.git"
+SRC_URI = "git://github.com/gordonjcp/${BPN}.git;protocol=https"
 SRCREV = "593d4be0ff6b4279e1b2b1bacbd5b6b02221358a"
 S = "${WORKDIR}/git"
 PV = "0.2+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/openav/arty-fx_1.3.bb
+++ b/recipes-misc/recipes-multimedia/openav/arty-fx_1.3.bb
@@ -13,7 +13,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/openAVproductions/openAV-ArtyFX.git \
+    git://github.com/openAVproductions/openAV-ArtyFX.git;protocol=https \
     file://0001-Do-not-overwrite-build-flags-it-causes-trouble-for-m.patch \
     file://0002-avtk-remove-sse-flags-they-work-on-intel-hardware-on.patch \
 "

--- a/recipes-misc/recipes-multimedia/openav/fabla_git.bb
+++ b/recipes-misc/recipes-multimedia/openav/fabla_git.bb
@@ -14,7 +14,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/openAVproductions/openAV-Fabla.git \
+    git://github.com/openAVproductions/openAV-Fabla.git;protocol=https \
     file://0001-Do-not-overwrite-build-flags-it-causes-trouble-for-m.patch \
 "
 SRCREV = "05bb8d4704a601e660dcd146caf5899d4a4cc5cc"

--- a/recipes-misc/recipes-multimedia/openav/luppp_git.bb
+++ b/recipes-misc/recipes-multimedia/openav/luppp_git.bb
@@ -15,7 +15,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/openAVproductions/openAV-Luppp.git \
+    git://github.com/openAVproductions/openAV-Luppp.git;protocol=https \
     file://0001-CMake-Remove-arch-detection-it-detects-build-host.patch \
 "
 SRCREV = "289313ce132133d5d3c86724a1e3b488260d1728"

--- a/recipes-misc/recipes-multimedia/openav/openav-presets_git.bb
+++ b/recipes-misc/recipes-multimedia/openav/openav-presets_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 inherit allarch
 
 SRC_URI = " \
-    git://github.com/harryhaaren/openAV-presets.git \
+    git://github.com/harryhaaren/openAV-presets.git;protocol=https \
 "
 SRCREV = "c52ded5002b1bdf05bae3fe692b259a6b414942c"
 PV = "0.0.0+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/openav/sorcer_git.bb
+++ b/recipes-misc/recipes-multimedia/openav/sorcer_git.bb
@@ -13,7 +13,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/openAVproductions/openAV-Sorcer.git \
+    git://github.com/openAVproductions/openAV-Sorcer.git;protocol=https \
     file://0001-Do-not-overwrite-build-flags-it-causes-trouble-for-m.patch \
 "
 SRCREV = "0a8cef484174aae5c1b7be6710f31a643e7d7197"

--- a/recipes-misc/recipes-multimedia/polyphone/polyphone_1.9.bb
+++ b/recipes-misc/recipes-multimedia/polyphone/polyphone_1.9.bb
@@ -19,7 +19,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/davy7125/polyphone.git \
+    git://github.com/davy7125/polyphone.git;protocol=https \
     file://polyphone.desktop \
     file://polyphone.mime \
     file://0001-align-compiler-switches-constants-for-cross-compilin.patch \

--- a/recipes-misc/recipes-multimedia/projectm/projectm_git.bb
+++ b/recipes-misc/recipes-multimedia/projectm/projectm_git.bb
@@ -14,7 +14,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/projectM-visualizer/projectm.git;name=projectm \
+    git://github.com/projectM-visualizer/projectm.git;name=projectm;protocol=https \
 	http://spiegelmc.com.s3.amazonaws.com/pub/projectm_presets.zip;name=presets \
     file://0001-find-native-qt-build-tools-by-configure-options-auto.patch \
     file://0002-Makefile.am-Fix-installation-with-DESTDIR-set.patch \

--- a/recipes-misc/recipes-multimedia/qmidiarp/qmidiarp_0.6.5.bb
+++ b/recipes-misc/recipes-multimedia/qmidiarp/qmidiarp_0.6.5.bb
@@ -14,7 +14,7 @@ DEPENDS += " \
 inherit qmake5_base autotools-brokensep pkgconfig gtk-icon-cache qt5-translation
 
 SRC_URI = " \
-    git://github.com/emuse/qmidiarp.git \
+    git://github.com/emuse/qmidiarp.git;protocol=https \
     file://0001-remove-code-to-find-qtwidget-headers-it-finds-host-s.patch \
     file://0002-find-native-qt-build-tools-by-configure-options-auto.patch \
     file://qmidiarp-alsa.desktop \

--- a/recipes-misc/recipes-multimedia/rncbc/drumkv1_0.9.1.bb
+++ b/recipes-misc/recipes-multimedia/rncbc/drumkv1_0.9.1.bb
@@ -16,7 +16,7 @@ inherit qmake5_base autotools-brokensep pkgconfig gtk-icon-cache mime
 
 SRC_URI = " \
     ${SOURCEFORGE_MIRROR}/project/${BPN}/${BPN}/${PV}/${BPN}-${PV}.tar.gz \
-    git://github.com/TuriSc/hydrogen2drumkv1.py.git;name=hydrogen2drumkv1;destsuffix=hydrogen2drumkv1 \
+    git://github.com/TuriSc/hydrogen2drumkv1.py.git;name=hydrogen2drumkv1;destsuffix=hydrogen2drumkv1;protocol=https \
     file://0001-find-native-qt-build-tools-by-configure-options-auto.patch \
 "
 SRC_URI[md5sum] = "fed5cf375dcd7e97291ed38d632fa773"

--- a/recipes-misc/recipes-multimedia/rncbc/qtractor_0.9.1.bb
+++ b/recipes-misc/recipes-multimedia/rncbc/qtractor_0.9.1.bb
@@ -18,7 +18,7 @@ DEPENDS += " \
 inherit qmake5_base autotools-brokensep pkgconfig gtk-icon-cache mime qt5-translation
 
 SRC_URI = " \
-    git://github.com/rncbc//qtractor.git;branch=midiimportx \
+    git://github.com/rncbc//qtractor.git;branch=midiimportx;protocol=https \
     file://0001-find-native-qt-build-tools-by-configure-options-auto.patch \
     \
     file://0001-do-nor-try-run-for-float-sse-detection.patch \

--- a/recipes-misc/recipes-multimedia/setbfree/setbfree_git.bb
+++ b/recipes-misc/recipes-multimedia/setbfree/setbfree_git.bb
@@ -19,7 +19,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/pantherb/setBfree.git \
+    git://github.com/pantherb/setBfree.git;protocol=https \
     file://0001-remove-UINQHACK-it-is-used-for-OSX-builds-only-and-c.patch \
     file://0002-Do-not-check-for-fontfile.patch \
 "

--- a/recipes-misc/recipes-multimedia/smbolton/fluidsynth-dssi_1.0.0.bb
+++ b/recipes-misc/recipes-multimedia/smbolton/fluidsynth-dssi_1.0.0.bb
@@ -13,7 +13,7 @@ DEPENDS += " \
     ladspa-sdk \
 "
 
-SRC_URI = "git://github.com/schnitzeltony/fluidsynth-dssi.git"
+SRC_URI = "git://github.com/schnitzeltony/fluidsynth-dssi.git;protocol=https"
 SRCREV = "bad09c6f5c5508c5f5330aa5188510f975e50c50"
 S = "${WORKDIR}/git"
 PV = "1.0.0+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/smbolton/hexter_1.1.0.bb
+++ b/recipes-misc/recipes-multimedia/smbolton/hexter_1.1.0.bb
@@ -13,7 +13,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/smbolton/hexter.git \
+    git://github.com/smbolton/hexter.git;protocol=https \
     file://hexter.desktop \
     file://hexter.png \
 "

--- a/recipes-misc/recipes-multimedia/soundfont-collection/sf-tools_git.bb
+++ b/recipes-misc/recipes-multimedia/soundfont-collection/sf-tools_git.bb
@@ -3,7 +3,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=75859989545e37968a99b631ef42722e \
 "
-SRC_URI = "git://github.com/schnitzeltony/soundfont-cmdline-tools.git"
+SRC_URI = "git://github.com/schnitzeltony/soundfont-cmdline-tools.git;protocol=https"
 SRCREV = "c4b11144dc714d9e4d959f0631c35a6b9764c057"
 S = "${WORKDIR}/git"
 PV = "0.0.0+git${SRCPV}"

--- a/recipes-misc/recipes-multimedia/tomahawk/tomahawk_git.bb
+++ b/recipes-misc/recipes-multimedia/tomahawk/tomahawk_git.bb
@@ -9,7 +9,7 @@ DEPENDS += " \
 "
 
 SRC_URI = " \
-    git://github.com/tomahawk-player/${BPN}.git;protocol=git \
+    git://github.com/tomahawk-player/${BPN}.git;protocol=https \
     file://0001-use-pkg-config-to-find-taglib.patch \
 "
 SRCREV = "7e96285132921936b3a62202d894d5288e5890d2"

--- a/recipes-misc/recipes-multimedia/x42/avldrums.lv2_git.bb
+++ b/recipes-misc/recipes-multimedia/x42/avldrums.lv2_git.bb
@@ -14,7 +14,7 @@ DEPENDS += " \
     lv2 \
 "
 
-SRC_URI = "gitsm://github.com/x42/avldrums.lv2.git"
+SRC_URI = "gitsm://github.com/x42/avldrums.lv2.git;protocol=https"
 SRCREV = "856f794c38a1769d108235e4ffb734c1f025f150"
 PV = "0.2.2+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-multimedia/x42/fil4.lv2_git.bb
+++ b/recipes-misc/recipes-multimedia/x42/fil4.lv2_git.bb
@@ -16,7 +16,7 @@ DEPENDS += " \
     fftw \
 "
 
-SRC_URI = "gitsm://github.com/x42/fil4.lv2.git"
+SRC_URI = "gitsm://github.com/x42/fil4.lv2.git;protocol=https"
 SRCREV = "46bbbc1830be479364ee3b09e1167c36765bbc03"
 PV = "0.4.4+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-multimedia/x42/meters.lv2_git.bb
+++ b/recipes-misc/recipes-multimedia/x42/meters.lv2_git.bb
@@ -16,7 +16,7 @@ DEPENDS += " \
     fftw \
 "
 
-SRC_URI = "gitsm://github.com/x42/meters.lv2.git"
+SRC_URI = "gitsm://github.com/x42/meters.lv2.git;protocol=https"
 SRCREV = "3d44ee52d78d7a04f083a3c9140c5a6c8f057293"
 PV = "0.9.4+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-multimedia/x42/midifilter.lv2_git.bb
+++ b/recipes-misc/recipes-multimedia/x42/midifilter.lv2_git.bb
@@ -7,7 +7,7 @@ inherit autotools-brokensep pkgconfig
 
 DEPENDS += "lv2"
 
-SRC_URI = "git://github.com/x42/midifilter.lv2.git"
+SRC_URI = "git://github.com/x42/midifilter.lv2.git;protocol=https"
 SRCREV = "5b2b0976b1cbdb7533bea23d1fcac45e21803edd"
 PV = "0.4.7+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-multimedia/x42/tuna.lv2_git.bb
+++ b/recipes-misc/recipes-multimedia/x42/tuna.lv2_git.bb
@@ -16,7 +16,7 @@ DEPENDS += " \
     fftw \
 "
 
-SRC_URI = "gitsm://github.com/x42/tuna.lv2.git"
+SRC_URI = "gitsm://github.com/x42/tuna.lv2.git;protocol=https"
 SRCREV = "d0c5044df527042d4d2b5365b5706ad151ca033d"
 PV = "0.4.4+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-themes/adwaita-qt/adwaita-qt_1.0.bb
+++ b/recipes-misc/recipes-themes/adwaita-qt/adwaita-qt_1.0.bb
@@ -7,7 +7,7 @@ inherit cmake_qt5
 
 DEPENDS = "qtbase"
 
-SRC_URI = "git://github.com/MartinBriza/${BPN}.git"
+SRC_URI = "git://github.com/MartinBriza/${BPN}.git;protocol=https"
 SRCREV = "34900be926b1779315af0846856860f51087fc79"
 S = "${WORKDIR}/git"
 

--- a/recipes-support/cmst/cmst_2018.01.06.bb
+++ b/recipes-support/cmst/cmst_2018.01.06.bb
@@ -8,7 +8,7 @@ inherit qmake5 gtk-icon-cache
 
 DEPENDS += "connman qtbase"
 
-SRC_URI = "git://github.com/andrew-bibb/cmst.git"
+SRC_URI = "git://github.com/andrew-bibb/cmst.git;protocol=https"
 SRCREV = "cf41767dfbb849f9c05bcdfc7fcb6a37c90b2ad0"
 S = "${WORKDIR}/git"
 

--- a/recipes-support/lmdb/lmdb_0.9.21.bb
+++ b/recipes-support/lmdb/lmdb_0.9.21.bb
@@ -4,7 +4,7 @@ LICENSE = "OLDAP-2.8"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=153d07ef052c4a37a8fac23bc6031972"
 
 SRC_URI = " \
-    git://github.com/LMDB/lmdb.git;branch=mdb.RE/0.9 \
+    git://github.com/LMDB/lmdb.git;branch=mdb.RE/0.9;protocol=https \
     file://0001-Patch-the-main-Makefile.patch \
 "
 SRCREV = "60d500206a108b2c64ca7e36b0113b2cd3711b98"

--- a/recipes-support/mlt/mlt_6.6.0.bb
+++ b/recipes-support/mlt/mlt_6.6.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = " \
-    git://github.com/mltframework/mlt.git \
+    git://github.com/mltframework/mlt.git;protocol=https \
 "
 SRCREV = "aea7f984b85ac61a4052d6ae17ce981d0530548e"
 S = "${WORKDIR}/git"

--- a/recipes-support/muparser/muparser_2.2.5.bb
+++ b/recipes-support/muparser/muparser_2.2.5.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://beltoforion.de/article.php?a=muparser"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://License.txt;md5=7330c66af0fadfe6e8c17069e8e726f2"
 
-SRC_URI = "git://github.com/beltoforion/muparser.git"
+SRC_URI = "git://github.com/beltoforion/muparser.git;protocol=https"
 SRCREV = "57e7e28614579eafe061dba1f77acc855640882d"
 S = "${WORKDIR}/git"
 

--- a/recipes-trueos/lumina/lumina_git.bb
+++ b/recipes-trueos/lumina/lumina_git.bb
@@ -18,7 +18,7 @@ DEPENDS += " \
     poppler \
 "
 
-SRC_URI = "git://github.com/trueos/lumina.git"
+SRC_URI = "git://github.com/trueos/lumina.git;protocol=https"
 SRCREV = "afcece7d649bf7fecb39c815d5b5603d31df00c9"
 S = "${WORKDIR}/git"
 PV = "1.4.0+git${SRCPV}"


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 