### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/classes/liri.bbclass
+++ b/classes/liri.bbclass
@@ -1,6 +1,6 @@
 LIRI_GIT_BRANCH ?= "develop"
 
-SRC_URI = "git://github.com/lirios/${@'${BPN}'.replace('liri-', '')}.git;protocol=git;branch=${LIRI_GIT_BRANCH}"
+SRC_URI = "git://github.com/lirios/${@'${BPN}'.replace('liri-', '')}.git;protocol=https;branch=${LIRI_GIT_BRANCH}"
 
 DEPENDS += " \
     qtwayland-native \

--- a/classes/lxqt.bbclass
+++ b/classes/lxqt.bbclass
@@ -4,5 +4,5 @@ HOMEPAGE = "http://lxqt.org/"
 
 DEPENDS += "lxqt-build-tools qtbase qttools-native"
 
-SRC_URI = "git://github.com/lxqt/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/lxqt/${BPN}.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"

--- a/extends-meta-qt5/quazip.bb
+++ b/extends-meta-qt5/quazip.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4c01c380a79ed7138aa9049e29df9c6a"
 
 DEPENDS = "qtbase zlib"
 
-SRC_URI = "git://github.com/stachenov/quazip.git"
+SRC_URI = "git://github.com/stachenov/quazip.git;protocol=https"
 SRCREV = "100578f686b7da029a19c0bc9ad3c93f80adb2bb"
 PV = "1.1"
 S = "${WORKDIR}/git"

--- a/recipes-graphics/picom/picom.bb
+++ b/recipes-graphics/picom/picom.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/yshui/picom"
 LICENSE = "MPL-2.0 & MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a9a621b5a1b8f702c605093d657b550c"
 
-SRC_URI = "git://github.com/yshui/picom.git;branch=stable/8"
+SRC_URI = "git://github.com/yshui/picom.git;branch=stable/8;protocol=https"
 SRCREV = "dac85eac10082dfc3df463aaa74b811144e22122"
 PV = "8.2"
 S = "${WORKDIR}/git"

--- a/recipes-graphics/sddm/sddm_git.bb
+++ b/recipes-graphics/sddm/sddm_git.bb
@@ -17,7 +17,7 @@ PACKAGECONFIG[pam] = "-DENABLE_PAM=ON, -DENABLE_PAM=OFF, libpam"
 # Note: we should check default config changes by running sddm --example-config on target.
 # This is usually done during build but does not work for our cross environment
 SRC_URI = " \
-    git://github.com/sddm/${BPN}.git;protocol=git;branch=master \
+    git://github.com/sddm/${BPN}.git;protocol=https;branch=master \
     file://0001-fix-qml-install-dir.patch \
     file://0002-Workaround-missing-sessions.patch \
     file://sddm.pam \

--- a/recipes-kdab/hotspot/hotspot_git.bb
+++ b/recipes-kdab/hotspot/hotspot_git.bb
@@ -21,7 +21,7 @@ DEPENDS += " \
     kio \
     solid \
 "
-SRC_URI = "gitsm://github.com/KDAB/hotspot.git"
+SRC_URI = "gitsm://github.com/KDAB/hotspot.git;protocol=https"
 SRCREV = "35d1865babf40b9df454810ca8cc09e77b0c349a"
 S = "${WORKDIR}/git"
 PV = "1.2.0+git${SRCPV}"

--- a/recipes-kdab/kdcharts/kdcharts_git.bb
+++ b/recipes-kdab/kdcharts/kdcharts_git.bb
@@ -17,7 +17,7 @@ do_install_append() {
     rm -r ${D}/usr/mkspecs
 }
 
-SRC_URI = "git://github.com/KDAB/KDChart.git"
+SRC_URI = "git://github.com/KDAB/KDChart.git;protocol=https"
 SRCREV = "95547e8a2f6c362db1dd071a2df00b0e75e05da0"
 S = "${WORKDIR}/git"
 PV = "2.7.2"

--- a/recipes-kdab/kdreports/kdreports_git.bb
+++ b/recipes-kdab/kdreports/kdreports_git.bb
@@ -12,7 +12,7 @@ DEPENDS += " \
     kdcharts \
 "
 
-SRC_URI = "git://github.com/KDAB/KDReports.git"
+SRC_URI = "git://github.com/KDAB/KDReports.git;protocol=https"
 SRCREV = "47728293e7842140d36a7861cf4316f2c1cbd795"
 S = "${WORKDIR}/git"
 PV = "1.9.0"

--- a/recipes-liri/slime-engine/slime-engine_git.bb
+++ b/recipes-liri/slime-engine/slime-engine_git.bb
@@ -8,7 +8,7 @@ inherit qmake5
 
 PV = "0.0.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/tim-sueberkrueb/${BPN}.git"
+SRC_URI = "git://github.com/tim-sueberkrueb/${BPN}.git;protocol=https"
 SRCREV = "9d2fd26da9c38b2e5c4c1c4d994b193213559e2f"
 S = "${WORKDIR}/git"
 

--- a/recipes-lumina/lumina-desktop/lumina-calculator.bb
+++ b/recipes-lumina/lumina-desktop/lumina-calculator.bb
@@ -15,7 +15,7 @@ DEPENDS += " \
     qtsvg \
 "
 
-SRC_URI = "git://github.com/lumina-desktop/lumina-calculator.git"
+SRC_URI = "git://github.com/lumina-desktop/lumina-calculator.git;protocol=https"
 SRCREV = "31807e06a3a6bd194bad6b0fd204ca2d81cc3810"
 S = "${WORKDIR}/git/src-qt5"
 PV = "1.6.0"

--- a/recipes-lumina/lumina-desktop/lumina-pdf.bb
+++ b/recipes-lumina/lumina-desktop/lumina-pdf.bb
@@ -15,7 +15,7 @@ DEPENDS += " \
     poppler \
 "
 
-SRC_URI = "git://github.com/lumina-desktop/lumina-pdf.git"
+SRC_URI = "git://github.com/lumina-desktop/lumina-pdf.git;protocol=https"
 SRCREV = "808a6a17a399b5c38801256985181d735b569e24"
 S = "${WORKDIR}/git/src-qt5"
 PV = "1.6.0"

--- a/recipes-lumina/lumina-desktop/lumina.bb
+++ b/recipes-lumina/lumina-desktop/lumina.bb
@@ -17,7 +17,7 @@ DEPENDS += " \
     qtsvg \
 "
 
-SRC_URI = "git://github.com/lumina-desktop/lumina.git"
+SRC_URI = "git://github.com/lumina-desktop/lumina.git;protocol=https"
 SRCREV = "ee85f9b4254ee98a06d169d14fb3cbb37c74f098"
 S = "${WORKDIR}/git"
 PV = "1.6.0"

--- a/recipes-lxqt/lxmenu-data/lxmenu-data.bb
+++ b/recipes-lxqt/lxmenu-data/lxmenu-data.bb
@@ -6,7 +6,7 @@ inherit autotools gettext
 
 DEPENDS = "glib-2.0-native intltool-native"
 
-SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=https;branch=master"
 S = "${WORKDIR}/git"
 
 SRCREV = "3b14415ff9862e6b79577fd4b9a097965001b270"

--- a/recipes-lxqt/lxqt-build-tools/lxqt-build-tools.bb
+++ b/recipes-lxqt/lxqt-build-tools/lxqt-build-tools.bb
@@ -9,7 +9,7 @@ do_configure_append() {
     sed -i 's:set(LXQT_ETC_XDG_DIR.*:set(LXQT_ETC_XDG_DIR        "${sysconfdir}/xdg"):' ${B}/install/LXQtConfigVars.cmake
 }
 
-SRC_URI = "git://github.com/lxde/${BPN}.git"
+SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=https"
 SRCREV = "42de723edf3e342e554b9e02345d32c86fec7691"
 PV = "0.9.0"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-chemistry/avogadro/avogadrolibs.inc
+++ b/recipes-misc/recipes-chemistry/avogadro/avogadrolibs.inc
@@ -7,6 +7,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=68485d31f72dbb8611179b6c7515617b"
 inherit cmake_qt5 python3native
 
 PV = "1.93.1"
-SRC_URI = "git://github.com/OpenChemistry/avogadrolibs.git"
+SRC_URI = "git://github.com/OpenChemistry/avogadrolibs.git;protocol=https"
 SRCREV = "4f1b21de000046c04a39829063c6416fbd70922b"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-chemistry/libmsym/libmsym_git.bb
+++ b/recipes-misc/recipes-chemistry/libmsym/libmsym_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=60a6a261d3c9d47b608d8e02d24c119a"
 
 inherit cmake cmake_lib
 
-SRC_URI = "git://github.com/mcodev31/${BPN}.git"
+SRC_URI = "git://github.com/mcodev31/${BPN}.git;protocol=https"
 SRCREV = "c99470376270db4ec4c925b952fa722e011377d6"
 S = "${WORKDIR}/git"
 PV = "0.2.3"

--- a/recipes-misc/recipes-chemistry/mmtf/mmtf-cpp_1.0.0.bb
+++ b/recipes-misc/recipes-chemistry/mmtf/mmtf-cpp_1.0.0.bb
@@ -7,7 +7,7 @@ inherit cmake
 
 DEPENDS = "msgpack-c"
 
-SRC_URI = "git://github.com/rcsb/mmtf-cpp.git"
+SRC_URI = "git://github.com/rcsb/mmtf-cpp.git;protocol=https"
 SRCREV = "407bf8e541530579b1f2c3e7f7fa96bb06ef5be9"
 S = "${WORKDIR}/git"
 

--- a/recipes-misc/recipes-chemistry/molequeue/molequeue_git.bb
+++ b/recipes-misc/recipes-chemistry/molequeue/molequeue_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e64c567d31d109fd44cbe6f1fe113daa"
 inherit cmake_qt5 cmake_lib
 
 SRC_URI = " \
-    git://github.com/OpenChemistry/molequeue.git \
+    git://github.com/OpenChemistry/molequeue.git;protocol=https \
     file://0001-Avoid-RPATH-if-not-configured.patch \
     file://0002-MoleQueueConfig.cmake-Find-include.patch \
 "

--- a/recipes-misc/recipes-chemistry/openbabel/openbabel_git.bb
+++ b/recipes-misc/recipes-chemistry/openbabel/openbabel_git.bb
@@ -13,7 +13,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-    git://github.com/openbabel/openbabel.git \
+    git://github.com/openbabel/openbabel.git;protocol=https \
     file://0001-Workaround-xdr-linker-error.patch \
     file://openbabel-gui.desktop \
 "

--- a/recipes-misc/recipes-chemistry/spglib/spglib.bb
+++ b/recipes-misc/recipes-chemistry/spglib/spglib.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=5e13e4b13c9ea72dbc9fda34255d9371"
 
 inherit autotools
 
-SRC_URI = "git://github.com/atztogo/spglib.git"
+SRC_URI = "git://github.com/atztogo/spglib.git;protocol=https"
 SRCREV = "e8118d854a4c11dbaa8d7b2c55d4a1e74ddcaaf7"
 S = "${WORKDIR}/git"
 PV = "1.16.1"

--- a/recipes-misc/recipes-hardhelper/pulseview/pulseview.bb
+++ b/recipes-misc/recipes-hardhelper/pulseview/pulseview.bb
@@ -20,7 +20,7 @@ PACKAGECONFIG ??= "decode"
 inherit cmake_qt5 mime-xdg
 
 SRC_URI = " \
-    git://github.com/sigrokproject/pulseview.git \
+    git://github.com/sigrokproject/pulseview.git;protocol=https \
     file://0001-Move-C-linking-below-standard-includes-to-fix-build-.patch \
 "
 SRCREV = "89b7b94a048ec53e82f38412a4b65cabb609f395"

--- a/recipes-misc/recipes-hardhelper/qtiohelper/qtiohelper_git.bb
+++ b/recipes-misc/recipes-hardhelper/qtiohelper/qtiohelper_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=bd7b2c994af21d318bd2cd3b3f80c2d5"
 
 require recipes-qt/qt5/qt5.inc
 
-SRC_URI = "git://github.com/schnitzeltony/${BPN}.git;branch=master"
+SRC_URI = "git://github.com/schnitzeltony/${BPN}.git;branch=master;protocol=https"
 
 DEPENDS += "qtbase qtserialport"
 

--- a/recipes-misc/recipes-markdown/md-juggler.bb
+++ b/recipes-misc/recipes-markdown/md-juggler.bb
@@ -8,7 +8,7 @@ DEPENDS = " \
     qtbase \
 "
 
-SRC_URI = "git://github.com/schnitzeltony/md-juggler.git"
+SRC_URI = "git://github.com/schnitzeltony/md-juggler.git;protocol=https"
 SRCREV = "db9094b328863e301a0e691c7412befd84c17e7b"
 PV = "0.0.0+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-qml/fontawesome-qml.bb
+++ b/recipes-misc/recipes-qml/fontawesome-qml.bb
@@ -8,7 +8,7 @@ DEPENDS = " \
     sortfilterproxymodel \
 "
 
-SRC_URI = "gitsm://github.com/schnitzeltony/fontawesome-qml.git"
+SRC_URI = "gitsm://github.com/schnitzeltony/fontawesome-qml.git;protocol=https"
 SRCREV = "b4ed78971807db222644af2669d734e4dccc52dd"
 PV = "0.3.0"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-qml/ksyntax-highlighting-wrapper.bb
+++ b/recipes-misc/recipes-qml/ksyntax-highlighting-wrapper.bb
@@ -7,7 +7,7 @@ DEPENDS = " \
     syntax-highlighting \
 "
 
-SRC_URI = "git://github.com/schnitzeltony/ksyntax-highlighting-wrapper.git"
+SRC_URI = "git://github.com/schnitzeltony/ksyntax-highlighting-wrapper.git;protocol=https"
 SRCREV = "7f2f6d3d030cc0ed7beca43d3e7668a30f123ba1"
 PV = "0.2.0"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-qml/markdown-qt_git.bb
+++ b/recipes-misc/recipes-qml/markdown-qt_git.bb
@@ -14,7 +14,7 @@ DEPENDS = " \
     cmark \
 "
 
-SRC_URI = "gitsm://github.com/schnitzeltony/markdown-qt.git"
+SRC_URI = "gitsm://github.com/schnitzeltony/markdown-qt.git;protocol=https"
 SRCREV = "ea5c7f27918a86ee7cf6a9ef4b3b2a38e839c19a"
 PV = "0.1.1"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-qml/qmlarkdown.bb
+++ b/recipes-misc/recipes-qml/qmlarkdown.bb
@@ -11,7 +11,7 @@ DEPENDS = " \
     fontawesome-qml \
 "
 
-SRC_URI = "git://github.com/schnitzeltony/qmlarkdown.git"
+SRC_URI = "git://github.com/schnitzeltony/qmlarkdown.git;protocol=https"
 SRCREV = "1ee12b14c3c34297a96d8c97490671235a33fc8e"
 PV = "0.0.1+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-qml/sortfilterproxymodel.bb
+++ b/recipes-misc/recipes-qml/sortfilterproxymodel.bb
@@ -7,7 +7,7 @@ DEPENDS = " \
     qtdeclarative \
 "
 
-SRC_URI = "git://github.com/schnitzeltony/SortFilterProxyModel.git"
+SRC_URI = "git://github.com/schnitzeltony/SortFilterProxyModel.git;protocol=https"
 SRCREV = "3931d10330dfe01eb855805fdcb0d6da5c31b024"
 PV = "0.1.1+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-misc/recipes-themes/adwaita-qt/adwaita-qt.bb
+++ b/recipes-misc/recipes-themes/adwaita-qt/adwaita-qt.bb
@@ -9,7 +9,7 @@ REQUIRED_DISTRO_FEATURES = "x11"
 
 DEPENDS = "qtbase qtx11extras"
 
-SRC_URI = "git://github.com/FedoraQt/adwaita-qt.git;branch=1.3"
+SRC_URI = "git://github.com/FedoraQt/adwaita-qt.git;branch=1.3;protocol=https"
 SRCREV = "906c4d8e63b5a6cd2c54511ca5d6062515a79c5f"
 PV = "1.3.1"
 S = "${WORKDIR}/git"

--- a/recipes-remote-conversation/matrix/libquotient.bb
+++ b/recipes-remote-conversation/matrix/libquotient.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://matrix.org/docs/projects/sdk/quotient"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
-SRC_URI = "gitsm://github.com/quotient-im/libQuotient.git;branch=0.6.x"
+SRC_URI = "gitsm://github.com/quotient-im/libQuotient.git;branch=0.6.x;protocol=https"
 SRCREV = "a4e78956f105875625b572d8b98459ffa86fafe5"
 PV = "0.6.4"
 S = "${WORKDIR}/git"

--- a/recipes-remote-conversation/matrix/quaternion.bb
+++ b/recipes-remote-conversation/matrix/quaternion.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://matrix.org/docs/projects/client/quaternion"
 LICENSE = "GPL-3.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-SRC_URI = "git://github.com/quotient-im/Quaternion.git"
+SRC_URI = "git://github.com/quotient-im/Quaternion.git;protocol=https"
 SRCREV = "307116615d7ca0e08b2468f161531f3e21d24ae8"
 PV = "0.0.9.4e"
 S = "${WORKDIR}/git"

--- a/recipes-support/grantlee/grantlee.bb
+++ b/recipes-support/grantlee/grantlee.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/steveire/grantlee"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
-SRC_URI = "git://github.com/steveire/grantlee.git"
+SRC_URI = "git://github.com/steveire/grantlee.git;protocol=https"
 SRCREV = "b6454a97c9db3275f1a147a4dde1a02894dfbba0"
 S = "${WORKDIR}/git"
 

--- a/recipes-support/libdmtx/libdmtx_git.bb
+++ b/recipes-support/libdmtx/libdmtx_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b58872aaf3a9d51c1f002b9d7940f4f1"
 
 inherit autotools pkgconfig
 
-SRC_URI = "git://github.com/dmtx/libdmtx.git"
+SRC_URI = "git://github.com/dmtx/libdmtx.git;protocol=https"
 SRCREV = "53f001bbcb09f40747d645997f723fc96a58fec2"
 PV = "0.7.5"
 S = "${WORKDIR}/git"

--- a/recipes-support/lmdb/lmdb_git.bb
+++ b/recipes-support/lmdb/lmdb_git.bb
@@ -4,7 +4,7 @@ LICENSE = "OLDAP-2.8"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=153d07ef052c4a37a8fac23bc6031972"
 
 SRC_URI = " \
-    git://github.com/LMDB/lmdb.git;nobranch=1 \
+    git://github.com/LMDB/lmdb.git;nobranch=1;protocol=https \
     file://0001-Patch-the-main-Makefile.patch \
 "
 SRCREV = "8ad7be2510414b9506ec9f9e24f24d04d9b04a1a"

--- a/recipes-support/mlt/mlt.bb
+++ b/recipes-support/mlt/mlt.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = " \
     file://GPLv3;md5=d32239bcb673463ab874e80d47fae504 \
 "
 
-SRC_URI = "git://github.com/mltframework/mlt.git"
+SRC_URI = "git://github.com/mltframework/mlt.git;protocol=https"
 SRCREV = "902c4c2d82514e812b3129a0aa3146a89bb898ec"
 PV = "6.24.0"
 S = "${WORKDIR}/git"

--- a/recipes-support/muparser/muparser.bb
+++ b/recipes-support/muparser/muparser.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://beltoforion.de/article.php?a=muparser"
 LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://License.txt;md5=98f3ad1a0193387fc84b0101833605c8"
 
-SRC_URI = "git://github.com/beltoforion/muparser.git"
+SRC_URI = "git://github.com/beltoforion/muparser.git;protocol=https"
 SRCREV = "207d5b77c05c9111ff51ab91082701221220c477"
 PV = "2.3.2"
 S = "${WORKDIR}/git"

--- a/recipes-support/qtkeychain/qtkeychain.bb
+++ b/recipes-support/qtkeychain/qtkeychain.bb
@@ -13,7 +13,7 @@ QT_TRANSLATION_FILES = "${datadir}/qt5keychain/translations/*.qm"
 
 inherit cmake_qt5_extra qt5-translation
 
-SRC_URI = "git://github.com/frankosterfeld/${BPN}.git"
+SRC_URI = "git://github.com/frankosterfeld/${BPN}.git;protocol=https"
 SRCREV = "815fe610353ff8ad7e2f1121c368a74df8db5eb7"
 PV = "0.12.0"
 S = "${WORKDIR}/git"

--- a/recipes-support/shlomif/pysol-cards.bb
+++ b/recipes-support/shlomif/pysol-cards.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/shlomif/pysol_cards"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5feec56facfce12352e96d26cab9b857"
 
-SRC_URI = "git://github.com/shlomif/pysol_cards.git"
+SRC_URI = "git://github.com/shlomif/pysol_cards.git;protocol=https"
 SRCREV = "eca7276fced32ab059da82060098ac6a7f19c226"
 PV = "0.10.1"
 S = "${WORKDIR}/git"

--- a/recipes-support/shlomif/rinutils.bb
+++ b/recipes-support/shlomif/rinutils.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/shlomif/rinutils"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=93a02b264605b1fd19838fde65a7ed37"
 
-SRC_URI = "git://github.com/shlomif/rinutils.git"
+SRC_URI = "git://github.com/shlomif/rinutils.git;protocol=https"
 SRCREV = "63c9a72554e2a2afc46823a21e59a3399f461d00"
 PV = "0.8.0"
 S = "${WORKDIR}/git"

--- a/recipes-support/telepathy/telepathy-qt_0.9.8.bb
+++ b/recipes-support/telepathy/telepathy-qt_0.9.8.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2d5025d4aa3495befef8f17206a5b0a1"
 DEPENDS = "qtbase python3"
 
 SRC_URI = " \
-    git://github.com/TelepathyIM/telepathy-qt.git \
+    git://github.com/TelepathyIM/telepathy-qt.git;protocol=https \
 "
 SRCREV = "6ccb59117fdb261016d06b42167c24c99cbcecc4"
 S = "${WORKDIR}/git"

--- a/recipes-support/translate-toolkit/translate-toolkit.bb
+++ b/recipes-support/translate-toolkit/translate-toolkit.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://toolkit.translatehouse.org/"
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/translate/translate.git"
+SRC_URI = "git://github.com/translate/translate.git;protocol=https"
 SRCREV = "d98ef03f11129fd2072c11474089a13030e93b7b"
 S = "${WORKDIR}/git"
 PV = "3.3.1"

--- a/recipes-support/umockdev/umockdev.bb
+++ b/recipes-support/umockdev/umockdev.bb
@@ -2,7 +2,7 @@ SUMMARY = "Mock hardware devices for creating unit tests and bug reporting"
 LICENSE = "LGPL-2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
-SRC_URI = "git://github.com/martinpitt/umockdev.git"
+SRC_URI = "git://github.com/martinpitt/umockdev.git;protocol=https"
 SRCREV = "8d53ab042b30dfb3f3be7cd9803aa8a545ef1f53"
 PV = "0.15.5"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos