### PR TITLE
meta-qt5-extra: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-misc/recipes-chemistry/avogadro/avogadrolibs.inc
+++ b/recipes-misc/recipes-chemistry/avogadro/avogadrolibs.inc
@@ -8,13 +8,14 @@ inherit cmake_qt5 python3native
 
 PV = "1.97.0"
 SRC_URI = " \
-    git://github.com/OpenChemistry/avogadrolibs.git;branch=master;protocol=https \
+    git://github.com/OpenChemistry/avogadrolibs.git;branch=master;protocol=https;name=avogadrolibs \
     git://github.com/OpenChemistry/molecules;branch=master;protocol=https;name=molecules;destsuffix=molecules \
     git://github.com/OpenChemistry/crystals;branch=master;protocol=https;name=crystals;destsuffix=crystals \
 "
 SRCREV = "82938e4f5ce188a1e53300d263167bebe717f5b2"
 SRCREV_molecules = "b1e16c5dc6d15e72d30dd6c4fca31b2c12025efc"
 SRCREV_crystals = "c3e2468fa42360499f0e73d215bddfe2245258aa"
+SRCREV_FORMAT = "avogadrolibs"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This is the 2024Q1.1 currency merge with upstream kirkstone branch
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2581791](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2581791)

Testing

- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable

@ni/rtos 