### PR TITLE
[next] layer.conf: assert nanbield compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,7 +23,7 @@ LAYERDEPENDS_meta-qt5-extra = " \
     gnome-layer \
     meta-python \
 "
-LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale"
+LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 


### PR DESCRIPTION
Just what it says on the tin.

[AB#2467374](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2467374)

# Testing
* [x] The core packagefeed builds with this change.

# Meta
* I submitted this to upstream in [schnitzeltony/meta-qt5-extra#93](https://github.com/schnitzeltony/meta-qt5-extra/pull/93). But I don't think we need to continue waiting for that to go in before unblocking further scarthgap dev.