### PR TITLE
meta-qt5-extra: Regular NILRT distro upstream merge

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,7 +23,7 @@ LAYERDEPENDS_meta-qt5-extra = " \
     gnome-layer \
     meta-python \
 "
-LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale"
+LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 


### PR DESCRIPTION
This is a regular NILRT distro upstream merge with master upstream branch.
There were no merge conflicts.
[AB#2657878](https://dev.azure.com/ni/DevCentral/_workitems/edit/2657878)

**Testing**

- [X]  bitbake packagefeed-ni-core
- [X] bitbake packagegroup-ni-desirable
- [X] bitbake package-index && bitbake nilrt-base-system-image
- [X] unpacked resulting nilrt-base-system-image-x64.tar on a VM and verified the target boots into runmode w/o problems.

**Note**

- maintainers please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).