### PR TITLE
Upstream merge for nilrt/kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,7 +23,7 @@ LAYERDEPENDS_meta-qt5-extra = " \
     gnome-layer \
     meta-python \
 "
-LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield"
+LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 

--- a/recipes-kde/kf5/tier1/kwayland/kwayland.bb
+++ b/recipes-kde/kf5/tier1/kwayland/kwayland.bb
@@ -15,6 +15,7 @@ DEPENDS += " \
     qtwayland-native \
     qtwayland \
     plasma-wayland-protocols \
+    wayland-protocols \
 "
 
 PV = "${KF5_VERSION}"

--- a/recipes-lxqt/lxqt-session/lxqt-session.bb
+++ b/recipes-lxqt/lxqt-session/lxqt-session.bb
@@ -13,7 +13,8 @@ DEPENDS += " \
     kwindowsystem \
 "
 
-SRC_URI += "file://0001-do-not-check-for-xdg-udser-dirs-at-build-time-it-is-.patch"
+SRC_URI += "file://0001-do-not-check-for-xdg-udser-dirs-at-build-time-it-is-.patch \
+            file://reaper-build-run-on-systems-with-procps-ng-4.0.0.patch"
 SRCREV = "55aa4bba19814ff678e6693e8b9c423455e8eccc"
 PV = "1.2.0"
 

--- a/recipes-lxqt/lxqt-session/lxqt-session/reaper-build-run-on-systems-with-procps-ng-4.0.0.patch
+++ b/recipes-lxqt/lxqt-session/lxqt-session/reaper-build-run-on-systems-with-procps-ng-4.0.0.patch
@@ -1,0 +1,85 @@
+The do_configure task for lxqt-session uses pkgconfig to find libprocps.
+
+However, newer releases are named libprocps2.  Allow either to be used.
+
+Upstream-Status: Backport[https://github.com/lxqt/lxqt-session/commit/d1db1c791195f3c0cf148e2be8bd46c5a51ca535]
+Signed-off-by: Rob Woolley <rob.woolley@windriver.com>
+
+From d1db1c791195f3c0cf148e2be8bd46c5a51ca535 Mon Sep 17 00:00:00 2001
+From: Palo Kisa <palo.kisa@gmail.com>
+Date: Tue, 7 Mar 2023 14:21:40 +0100
+Subject: [PATCH] reaper: Build/Run on systems with procps-ng >= 4.0.0 (#456)
+
+On Linux, make it possible to use libproc2 or libprocps whichever is
+available.
+---
+ CMakeLists.txt                  |  6 +++++-
+ lxqt-session/src/procreaper.cpp | 24 +++++++++++++++++++++++-
+ 2 files changed, 28 insertions(+), 2 deletions(-)
+
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -35,7 +35,11 @@ find_package(X11 REQUIRED)
+ message(STATUS "Building with Qt${Qt5Core_VERSION}")
+ find_package(PkgConfig REQUIRED)
+ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-    pkg_search_module(PROCPS REQUIRED libprocps)
++    pkg_search_module(PROCPS REQUIRED libproc2 libprocps)
++    message(STATUS "Using PROCPS -> ${PROCPS_MODULE_NAME} v${PROCPS_VERSION}")
++    if (PROCPS_VERSION VERSION_GREATER_EQUAL 4.0.0)
++        add_definitions("-DUSING_LIBPROC2")
++    endif()
+ endif()
+ 
+ 
+Index: git/lxqt-session/src/procreaper.cpp
+===================================================================
+--- git.orig/lxqt-session/src/procreaper.cpp
++++ git/lxqt-session/src/procreaper.cpp
+@@ -29,7 +29,11 @@
+ #include "log.h"
+ #if defined(Q_OS_LINUX)
+ #include <sys/prctl.h>
+-#include <proc/readproc.h>
++# if defined(USING_LIBPROC2)
++#  include <libproc2/pids.h>
++# else
++#  include <proc/readproc.h>
++# endif
+ #elif defined(Q_OS_FREEBSD)
+ #include <sys/procctl.h>
+ #include <libutil.h>
+@@ -109,6 +113,23 @@ void ProcReaper::stop(const std::set<int
+     const pid_t my_pid = ::getpid();
+     std::vector<pid_t> children;
+ #if defined(Q_OS_LINUX)
++# if defined(USING_LIBPROC2)
++    constexpr pids_item items[] = { PIDS_ID_PPID, PIDS_ID_TGID };
++    enum rel_items { rel_ppid, rel_tgid };
++    pids_info * info = nullptr;
++    procps_pids_new(&info, const_cast<pids_item *>(items), sizeof(items) / sizeof(pids_item));
++    pids_stack * stack = nullptr;
++    while ((stack = procps_pids_get(info, PIDS_FETCH_TASKS_ONLY)))
++    {
++        const int ppid = PIDS_VAL(rel_ppid, s_int, stack, info);
++        if (ppid == my_pid)
++        {
++            const int tgid = PIDS_VAL(rel_tgid, s_int, stack, info);
++            children.push_back(tgid);
++        }
++    }
++    procps_pids_unref(&info);
++# else
+     PROCTAB * proc_dir = ::openproc(PROC_FILLSTAT);
+     while (proc_t * proc = ::readproc(proc_dir, nullptr))
+     {
+@@ -119,6 +140,7 @@ void ProcReaper::stop(const std::set<int
+         ::freeproc(proc);
+     }
+     ::closeproc(proc_dir);
++# endif
+ #elif defined(Q_OS_FREEBSD)
+     int cnt = 0;
+     if (kinfo_proc *proc_info = kinfo_getallproc(&cnt))

--- a/recipes-lxqt/obconf-qt/files/Fix-invalid-conversion-from-xmlError.patch
+++ b/recipes-lxqt/obconf-qt/files/Fix-invalid-conversion-from-xmlError.patch
@@ -1,0 +1,34 @@
+Fix invalid conversion from xmlError
+
+src/obconf-qt.cpp: In function 'int main(int, char**)':
+src/obconf-qt.cpp:233:36: error: invalid conversion from 'const xmlError*' {aka 'const _xmlError*'} to 'xmlErrorPtr' {aka '_xmlError*'} [-fpermissive]
+
+Upstream-Status: Backport[https://github.com/lxqt/obconf-qt/commit/9fc5e566ea6559c27238c9dd5ae914b767f6c251]
+
+Signed-off-by: Rob Woolley <rob.woolley@windriver.com>
+
+From 9fc5e566ea6559c27238c9dd5ae914b767f6c251 Mon Sep 17 00:00:00 2001
+From: Tsu Jan <tsujan2000@gmail.com>
+Date: Sun, 14 Jan 2024 14:28:24 +0330
+Subject: [PATCH] Fixed compilation
+
+Fixes https://github.com/lxqt/obconf-qt/issues/224
+---
+ CHANGELOG         | 4 ++++
+ CMakeLists.txt    | 2 +-
+ src/obconf-qt.cpp | 2 +-
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/obconf-qt.cpp b/src/obconf-qt.cpp
+index e07c236..0d5b442 100644
+--- a/src/obconf-qt.cpp
++++ b/src/obconf-qt.cpp
+@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
+ 
+   /* look for parsing errors */
+   {
+-    xmlErrorPtr e = xmlGetLastError();
++    const xmlError *e = xmlGetLastError();
+ 
+     if(e) {
+       QString message = QObject::tr("Error while parsing the Openbox configuration file.  Your configuration file is not valid XML.\n\nMessage: %1")

--- a/recipes-lxqt/obconf-qt/obconf-qt.bb
+++ b/recipes-lxqt/obconf-qt/obconf-qt.bb
@@ -6,7 +6,8 @@ inherit lxqt qt5-translation pkgconfig
 
 DEPENDS += "qtx11extras openbox"
 
-SRC_URI += "file://0001-finding-sed-does-not-work-and-is-not-neccessary.patch"
+SRC_URI += "file://0001-finding-sed-does-not-work-and-is-not-neccessary.patch \
+            file://Fix-invalid-conversion-from-xmlError.patch"
 SRCREV = "b8d486b8be0e66570a80489c3e9084ce143ffa42"
 PV = "0.16.2"
 


### PR DESCRIPTION
[Sustaining 2657887](https://dev.azure.com/ni/DevCentral/_workitems/edit/2657887): Regular NILRT distro upstream merge (i05)

With this PR, the latest changes of meta-qt5-extra will be merged to nilrt/master/kirkstone. There were no merge conflicts.

**Testing:**
Ran the following to generate images:
`bitbake packagefeed-ni-core`
`bitbake nilrt-safemode-rootfs`
`bitbake nilrt-base-system-image`
`bitbake nilrt-recovery-media`
`packagegroup-ni-desirable`

Installed the newly built `nilrt-base-system-image-x64.tar` on a VM and verified the target boots into run-mode without any problems.

@rajendra-desai-ni, @prasanna-nib, please review the changes.

Note: @ni/rtos, please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).