### PR TITLE
layer.conf: add wrynose compatability

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,7 +23,7 @@ LAYERDEPENDS_meta-qt5-extra = " \
     gnome-layer \
     meta-python \
 "
-LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield scarthgap styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield scarthgap styhead walnascar whinlatter wrynose"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 


### PR DESCRIPTION
layer.conf: add wrynose compatability

This is change is required as a part of the upstream merge since openembedded-core is moving to wrynose.

[AB#3738531](https://dev.azure.com/ni/DevCentral/_workitems/edit/3738531)

### Testing
- [X] Built packagefeed-ni-core, packagegroup-ni-desirable, nilrt-base-system-image, and nilrt-recovery-media
- [X] Provisioned a cRIO-9033 using the recovery image and successfully installed the new BSI